### PR TITLE
Make react/jsx-runtime external deps to respect host

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       fileName: (format) => `index.${format === 'es' ? 'mjs' : 'cjs'}`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
currently it breaks usage with next.js or somewhere using different version of React.
It fixes this.